### PR TITLE
Correção de um bug do actionable

### DIFF
--- a/Assets/Editor/ActivatorEditor.cs
+++ b/Assets/Editor/ActivatorEditor.cs
@@ -66,7 +66,11 @@ public class ActivatorEditor : Editor {
 						if(actionableElements_sp.GetArrayElementAtIndex(i).objectReferenceValue == act_elem){
 							actionableElements_sp.DeleteArrayElementAtIndex(i);
 						}
-					}
+                        if (actionableElements_sp.GetArrayElementAtIndex(i).objectReferenceValue == null)
+                        {
+                            actionableElements_sp.DeleteArrayElementAtIndex(i);
+                        }
+                    }
 				}
 			}
 


### PR DESCRIPTION
Quando usava o unlink ele ficava com uma posição vazia no array de elementos
