### PR TITLE
Bug fix: Gizmos not redrawing vertically

### DIFF
--- a/Assets/Scripts/Elements/Claw/ClawController.cs
+++ b/Assets/Scripts/Elements/Claw/ClawController.cs
@@ -179,17 +179,13 @@ public class ClawController : MonoBehaviour {
     void OnDrawGizmos()
     {
         // if claw per se has not been initialized yet, must set to the actiual position
-        if (clawPerSe.initialPos == Vector3.zero)
-        {
-            clawPerSe.initialPos = clawPerSe.transform.position;
-        }
         SpriteRenderer sR = clawPerSe.GetComponentInChildren<SpriteRenderer>();
         float clawSizeY = sR.bounds.extents.y;
         Vector3 From = new Vector3(clawPerSe.transform.position.x - 1f,
-                                   clawPerSe.initialPos.y + clawSizeY,
+                                   clawPerSe.transform.position.y + clawSizeY,
                                    clawPerSe.transform.position.z);
         Vector3 To = new Vector3(clawPerSe.transform.position.x + 1f,
-                                 clawPerSe.initialPos.y - minHeight - clawSizeY,
+                                 clawPerSe.transform.position.y - minHeight - clawSizeY,
                                  clawPerSe.transform.position.z);
         ClawUtils.allowDrawing = allowDrawing;
         ClawUtils.DrawRectangle(From, To, Color.red);


### PR DESCRIPTION
Antes, quando se movia a garra, o gizmos não se movia na mesma distância verticalmente, só horizontalmente
![antes](https://cloud.githubusercontent.com/assets/12474023/16429992/deec2496-3d4f-11e6-9953-e913dd6dda40.png)
![depois](https://cloud.githubusercontent.com/assets/12474023/16429999/e43d1d1a-3d4f-11e6-920a-e0d137234761.png)
